### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,14 +24,14 @@ services:
       - "akeneo:/var/www/html"
       - "packages:/src/packages"
   mariadb:
-    image: "mariadb"
+    image: "mariadb:5.5"
     environment:
       MYSQL_RANDOM_ROOT_PASSWORD: "yes"
       MYSQL_DATABASE: "akeneo"
       MYSQL_USER: "akeneo"
       MYSQL_PASSWORD: "akeneo"
   mongo:
-    image: "mongo"
+    image: "mongo:2.6"
 
 volumes:
   akeneo:


### PR DESCRIPTION
It has been noticed that this image uses the latest version of mariadb and mongo. Since there was an error with the latest mongo version when saving a product, the versions mentioned in the Akeneo specification should now be used and fixed in composer.json. See https://docs.akeneo.com/1.6/developer_guide/installation/system_requirements/system_requirements.html
